### PR TITLE
Allow collections to merge e.g. :consumes and :produces

### DIFF
--- a/src/route_swagger/doc.clj
+++ b/src/route_swagger/doc.clj
@@ -66,5 +66,5 @@
                                             :info    {:title   "Swagger API"
                                                       :version "0.0.1"}}))
   ([route-table docs]
-   (let [swagger-object (deep-merge {:paths (paths route-table)} docs)]
+   (let [swagger-object (deep-merge :into {:paths (paths route-table)} docs)]
      (inject-swagger-into-routes route-table swagger-object))))


### PR DESCRIPTION
Think this got lost in the Big Refactor, but very useful to allow interceptors to participate in serialisation/deserialisation of content/response.