### PR TITLE
using linked map for swagger routes aggregation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (defproject route-swagger
-  "0.1.0-SNAPSHOT"
+  "0.1.1-SNAPSHOT"
   :dependencies
   [[org.clojure/clojure "1.7.0"]
-
+   [frankiesardo/linked "1.2.6"]
    [metosin/ring-swagger "0.22.3"]
    [metosin/ring-swagger-ui "2.1.4-0"]]
   :source-paths ["src" "resources"]

--- a/src/route_swagger/doc.clj
+++ b/src/route_swagger/doc.clj
@@ -3,7 +3,8 @@
             [ring.swagger.common :refer [deep-merge]]
             [schema.core :as s]
             [plumbing.core :refer [map-vals]]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [linked.core :as linked]))
 
 (s/defn annotate
   "Attaches swagger documentation to an object"
@@ -54,8 +55,10 @@
          (for [{:keys [path method] :as route} route-table
                :let [docs (find-docs route)]
                :when (documented-handler? route)]
-           {path {method (ring-keys->swagger (apply deep-merge :into docs))}})))
-
+           (linked/map path 
+                       (linked/map method
+                                   (ring-keys->swagger 
+                                    (apply deep-merge :into docs)))))))
 
 (defn with-swagger
   "Attaches swagger information as a meta key to each documented route. The


### PR DESCRIPTION
As per originally described in [this Pedestal API issue](https://github.com/oliyh/pedestal-api/issues/13), this PR is for conserving routes definition order in json-swagger.

As advised by @oliyh it is making use of an ordered `linked map`, like `compojure-api`.

I tested it with my projects (previously using `compojure-api`) and it gives the expected resut.