### PR TITLE
Infer operationId from interceptor name

### DIFF
--- a/src/route_swagger/doc.clj
+++ b/src/route_swagger/doc.clj
@@ -53,12 +53,13 @@
   [route-table]
   (apply merge-with merge
          (for [{:keys [path method] :as route} route-table
-               :let [docs (find-docs route)]
+               :let [docs (find-docs route)
+                     operation-id (some-> route :interceptors last :name name)]
                :when (documented-handler? route)]
-           (linked/map path 
+           (linked/map path
                        (linked/map method
-                                   (ring-keys->swagger 
-                                    (apply deep-merge :into docs)))))))
+                                   (ring-keys->swagger
+                                    (apply deep-merge :into (cons {:operationId operation-id} docs))))))))
 
 (defn with-swagger
   "Attaches swagger information as a meta key to each documented route. The

--- a/test/route_swagger/core_test.clj
+++ b/test/route_swagger/core_test.clj
@@ -53,7 +53,8 @@
 (def delete-handler
   (sw.doc/annotate
     {:summary    "Delete resource with id"
-     :parameters {:query-params {:notify s/Bool}}}
+     :parameters {:query-params {:notify s/Bool}}
+     :operationId "delete-resource"}
     (i/interceptor
       {:name  ::delete-handler
        :enter (fn [{{:keys [query-params path-params headers]} :request :as context}]
@@ -120,7 +121,8 @@
                                :header {(req "auth") s/Str}}
                  :responses   {200      {:schema {:status s/Str}}
                                :default {:schema  {:result [s/Str]}
-                                         :headers {(req "Location") s/Str}}}}}
+                                         :headers {(req "Location") s/Str}}}
+                 :operationId "get-handler"}}
                "/x/:id"
                {:put
                 {:description "Requires id on path"
@@ -128,14 +130,16 @@
                  :parameters  {:path   {:id s/Int}
                                :header {(req "auth") s/Str}
                                :body   {:name s/Keyword}}
-                 :responses   {}}
+                 :responses   {}
+                 :operationId "put-handler"}
                 :delete
                 {:description "Requires id on path"
                  :summary     "Delete resource with id"
                  :parameters  {:path   {:id s/Int}
                                :header {(req "auth") s/Str}
                                :query  {:notify s/Bool}}
-                 :responses   {}}}}]
+                 :responses   {}
+                 :operationId "delete-resource"}}}]
     (is (= paths (sw.doc/paths routes)))))
 
 (defn make-app [options]


### PR DESCRIPTION
Ciao Frankie,

This change fixes https://github.com/oliyh/pedestal-api/issues/9 and gives a more complete Swagger implementation out of the box. It still allows the user to specify one if they wish, however, as shown in the test.

Cheers
Oliy