### PR TITLE
Fix to work with more secure resource-response

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -16,8 +16,8 @@
 (deftask testing []
   (set-env! :source-paths #(conj % "test")
             :dependencies #(into %
-                                 '[[io.pedestal/pedestal.service "0.4.0"]
-                                   [io.pedestal/pedestal.jetty "0.4.0"]
+                                 '[[io.pedestal/pedestal.service "0.5.2"]
+                                   [io.pedestal/pedestal.jetty "0.5.2"]
                                    [metosin/scjsv "0.2.0" :exclusions [org.clojure/core.async]]]))
   identity)
 

--- a/example/project.clj
+++ b/example/project.clj
@@ -3,10 +3,10 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [frankiesardo/route-swagger "0.1.0"]
+                 [frankiesardo/route-swagger "0.1.2-2-gf911ed8-SNAPSHOT"]
 
-                 [io.pedestal/pedestal.service "0.4.0"]
-                 [io.pedestal/pedestal.jetty "0.4.0"]
+                 [io.pedestal/pedestal.service "0.5.2"]
+                 [io.pedestal/pedestal.jetty "0.5.2"]
                  [ch.qos.logback/logback-classic "1.1.2"
                   :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.7"]

--- a/example/src/sample/service.clj
+++ b/example/src/sample/service.clj
@@ -4,8 +4,7 @@
             [ring.swagger.middleware :refer [stringify-error]]
             [io.pedestal.http :as bootstrap]
             [io.pedestal.http.route :as route]
-            [io.pedestal.http.route.definition :as definition]
-            [io.pedestal.impl.interceptor :refer [terminate]]
+            [io.pedestal.interceptor.chain :refer [terminate]]
             [io.pedestal.interceptor :as i]
             [io.pedestal.interceptor.error :as error]
             [io.pedestal.http.body-params :refer [body-params]]
@@ -272,7 +271,7 @@
 
 (defmacro defroutes [n doc routes]
   #_`(def ~n (s/with-fn-validation (-> ~routes definition/expand-routes (sw.doc/with-swagger ~doc))))
-  `(def ~n (-> ~routes definition/expand-routes (sw.doc/with-swagger ~doc))))
+  `(def ~n (-> ~routes route/expand-routes (sw.doc/with-swagger ~doc))))
 
 (def swagger-json (i/interceptor (sw.int/swagger-json)))
 (def swagger-ui (i/interceptor {:name  :foo

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
    [metosin/ring-swagger "0.22.3"]
    [metosin/ring-swagger-ui "2.1.4-0"]]
   :source-paths ["src" "resources"]
-  :profiles {:dev {:dependencies [[io.pedestal/pedestal.service "0.4.0"]
-                                  [io.pedestal/pedestal.jetty "0.4.0"]
+  :profiles {:dev {:dependencies [[io.pedestal/pedestal.service "0.5.2"]
+                                  [io.pedestal/pedestal.jetty "0.5.2"]
                                   [metosin/scjsv "0.2.0" :exclusions [org.clojure/core.async]]]}})

--- a/src/route_swagger/interceptor.clj
+++ b/src/route_swagger/interceptor.clj
@@ -39,7 +39,7 @@
                                "conf.js" (response (str "window.API_CONF = {url: \""
                                                         (apply url-for ::doc/swagger-json path-opts)
                                                         "\"};"))
-                               (resource-response res {:root "swagger-ui/"})))))})
+                               (resource-response res {:root "swagger-ui"})))))})
 
 (defn coerce-request
   "Creates an interceptor that coerces the params for the selected route,


### PR DESCRIPTION
A recent update to ring fixed a security hole in resource-response: https://github.com/ring-clojure/ring/commit/510b72c24257191c10ea2c6a93ce83ec7094aff4

The most recent pedestal update pulled in the new ring version with the new behaviour, therefore users of pedestal-api with the new pedestal have a broken swagger UI.

This change fixes it - would be grateful if you could merge and push out a release.

Cheers!